### PR TITLE
Remove view dependency from templates and correctly load partials

### DIFF
--- a/pystache/template.py
+++ b/pystache/template.py
@@ -52,18 +52,19 @@ class Template(object):
     # Closing tag delimiter
     ctag = '}}'
 
-    def __init__(self, template, context=None):
+    def __init__(self, template, context=None, template_loader=None):
         self.template = template
         self.context = context or {}
         self.compile_regexps()
+        self.template_loader = template_loader
 
     def render(self, template=None, context=None, encoding=None):
         """Turns a Mustache template into something wonderful."""
         template = template or self.template
         context = context or self.context
 
-        template = self.render_sections(template, context)
-        result = self.render_tags(template, context)
+        template = self.render_sections(template, context, encoding)
+        result = self.render_tags(template, context, encoding)
         if encoding is not None:
             result = result.encode(encoding)
         return result
@@ -78,7 +79,7 @@ class Template(object):
         tag = r"%(otag)s(#|=|&|!|>|\{)?(.+?)\1?%(ctag)s+"
         self.tag_re = re.compile(tag % tags)
 
-    def render_sections(self, template, context):
+    def render_sections(self, template, context, encoding):
         """Expands sections."""
         while 1:
             match = self.section_re.search(template)
@@ -97,11 +98,11 @@ class Template(object):
                     replacer = inner
             elif it and hasattr(it, 'keys') and hasattr(it, '__getitem__'):
                 if section[2] != '^':
-                    replacer = self.render(inner, it)
+                    replacer = self.render(inner, it, encoding=encoding)
             elif it:
                 insides = []
                 for item in it:
-                    insides.append(self.render(inner, item))
+                    insides.append(self.render(inner, item, encoding=encoding))
                 replacer = ''.join(insides)
             elif not it and section[2] == '^':
                 replacer = inner
@@ -110,7 +111,7 @@ class Template(object):
 
         return template
 
-    def render_tags(self, template, context):
+    def render_tags(self, template, context, encoding):
         """Renders all the tags in a template for a context."""
         while 1:
             match = self.tag_re.search(template)
@@ -120,13 +121,13 @@ class Template(object):
             tag, tag_type, tag_name = match.group(0, 1, 2)
             tag_name = tag_name.strip()
             func = modifiers[tag_type]
-            replacement = func(self, tag_name, context)
+            replacement = func(self, tag_name, context, encoding)
             template = template.replace(tag, replacement)
 
         return template
 
     @modifier(None)
-    def render_tag(self, tag_name, context):
+    def render_tag(self, tag_name, context, encoding):
         """Given a tag name and context, finds, escapes, and renders the tag."""
         raw = get_or_attr(context, tag_name, '')
         if not raw and raw is not 0:
@@ -134,29 +135,24 @@ class Template(object):
         return cgi.escape(unicode(raw))
 
     @modifier('!')
-    def render_comment(self, tag_name=None, context=None):
+    def render_comment(self, tag_name=None, context=None, encoding=None):
         """Rendering a comment always returns nothing."""
         return ''
 
     @modifier('{')
     @modifier('&')
-    def render_unescaped(self, tag_name=None, context=None):
+    def render_unescaped(self, tag_name=None, context=None, encoding=None):
         """Render a tag without escaping it."""
         return unicode(get_or_attr(context, tag_name, ''))
 
     @modifier('>')
-    def render_partial(self, tag_name=None, context=None):
+    def render_partial(self, tag_name=None, context=None, encoding=None):
         """Renders a partial within the current context."""
-        # Import view here to avoid import loop
-        from pystache.view import View
-
-        view = View(context=context)
-        view.template_name = tag_name
-
-        return view.render()
+        template = self.template_loader(tag_name, context=context)
+        return template.render(encoding=encoding)
 
     @modifier('=')
-    def render_delimiter(self, tag_name=None, context=None):
+    def render_delimiter(self, tag_name=None, context=None, encoding=None):
         """Changes the Mustache delimiter."""
         self.otag, self.ctag = tag_name.split(' ')
         self.compile_regexps()

--- a/pystache/template.py
+++ b/pystache/template.py
@@ -2,6 +2,15 @@ import re
 import cgi
 import collections
 
+try:
+    import collections.Callable
+    def check_callable(it):
+        return isinstance(it, collections.Callable)
+except ImportError:
+    def check_callable(it):
+        return hasattr(it, '__call__')
+    
+
 modifiers = {}
 def modifier(symbol):
     """Decorator for associating a function with a Mustache tag modifier.
@@ -81,7 +90,7 @@ class Template(object):
 
             it = get_or_attr(context, section_name, None)
             replacer = ''
-            if it and isinstance(it, collections.Callable):
+            if it and check_callable(it):
                 replacer = it(inner)
             elif it and not hasattr(it, '__iter__'):
                 if section[2] != '^':

--- a/pystache/view.py
+++ b/pystache/view.py
@@ -25,7 +25,13 @@ class View(object):
     template_encoding = None
 
     def __init__(self, template=None, context=None, **kwargs):
-        self.template = template
+        self.template_content = dict()
+        
+        if template is not None:
+            self.template_content[self.get_template_name()] = template
+        elif self.template is not None:
+            self.template_content[self.get_template_name()] = self.template
+
         self.context = context or {}
 
         # If the context we're handed is a View, we want to inherit
@@ -44,29 +50,36 @@ class View(object):
         if view.template_name:
             self.template_name = view.template_name
 
-    def load_template(self):
-        if self.template:
-            return self.template
+    def create_template(self, template_name=None, context=None):
+        content = self.load_template_content(template_name or self.get_template_name())
+        context = context or self
         
-        if self.template_file:
-            return self._load_template()
-        
-        name = self.get_template_name() + '.' + self.template_extension
-        
-        if isinstance(self.template_path, basestring):
-            self.template_file = os.path.join(self.template_path, name)
-            return self._load_template()
-        
-        for path in self.template_path:
-            self.template_file = os.path.join(path, name)
-            if os.path.exists(self.template_file):
-                return self._load_template()
-        
-        raise IOError('"%s" not found in "%s"' % (name, ':'.join(self.template_path),))
+        template = Template(content, context=context, template_loader=self.create_template)
+        return template
 
-    
-    def _load_template(self):
-        f = open(self.template_file, 'r')
+    def load_template_content(self, template_name):
+        # We may have content for this loaded already
+        template_content = self.template_content.get(template_name)
+        
+        if template_content is None:
+            template_content = self._load_template_content(template_name)
+            self.template_content[template_name] = template_content
+        return template_content
+
+    def _load_template_content(self, template_name):
+        template_file_name = '.'.join((template_name, self.template_extension))
+
+        if isinstance(self.template_path, basestring):
+            template_file_path = os.path.join(self.template_path, template_file_name)
+        else:
+            for path in self.template_path:
+                template_file_path = os.path.join(path, template_file_name)
+                if os.path.exists(template_file_path):
+                    break
+            else:
+                raise IOError('"%s" not found in "%s"' % (template_name, ':'.join(self.template_path),))
+
+        f = open(template_file_path, 'r')
         try:
             template = f.read()
             if self.template_encoding:
@@ -109,8 +122,8 @@ class View(object):
             return attr
 
     def render(self, encoding=None):
-        template = self.load_template()
-        return Template(template, self).render(encoding=encoding)
+        template = self.create_template()
+        return template.render(encoding=encoding)
 
     def __str__(self):
         return self.render()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,6 +12,7 @@ from examples.delimiters import Delimiters
 from examples.unicode_output import UnicodeOutput
 from examples.unicode_input import UnicodeInput
 from examples.nested_context import NestedContext
+from examples.partial_section import PartialSection
 
 class TestView(unittest.TestCase):
     def test_comments(self):
@@ -55,7 +56,8 @@ Again, Welcome!""")
         self.assertEquals(view.render(), """Welcome
 -------
 
-Again, Welcome!
+## Again, Welcome! ##
+
 """)
 
 
@@ -67,6 +69,11 @@ Again, Welcome!
 
 * Then, surprisingly, it worked the third time.
 """)
+
+    def test_partial_sections(self):
+        view = PartialSection()
+        self.assertEquals(view.render(), """Welcome, we're loading partials
+This is item aThis is item b""")
 
     def test_nested_context(self):
         self.assertEquals(NestedContext().render(), "one and foo and two")

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -47,8 +47,7 @@ class TestView(unittest.TestCase):
         self.assertEquals(view.render(), "Hi Chris!")
 
     def test_view_instances_as_attributes(self):
-        other = Simple(name='chris')
-        other.template = '{{name}}'
+        other = Simple(name='chris', template='{{name}}')
         view = Simple()
         view.thing = other
         self.assertEquals(view.render(), "Hi chris!")
@@ -67,13 +66,11 @@ class TestView(unittest.TestCase):
                           'bar != bar. oh, it does!')
 
     def test_higher_order_rot13(self):
-        view = Lambdas()
-        view.template = '{{#rot13}}abcdefghijklm{{/rot13}}'
+        view = Lambdas(template='{{#rot13}}abcdefghijklm{{/rot13}}')
         self.assertEquals(view.render(), 'nopqrstuvwxyz')
 
     def test_higher_order_lambda(self):
-        view = Lambdas()
-        view.template = '{{#sort}}zyxwvutsrqponmlkjihgfedcba{{/sort}}'
+        view = Lambdas(template='{{#sort}}zyxwvutsrqponmlkjihgfedcba{{/sort}}')
         self.assertEquals(view.render(), 'abcdefghijklmnopqrstuvwxyz')
 
     def test_inverted(self):


### PR DESCRIPTION
See issue #13

Rather than have template rendering create a new view for rendering a partial, have all partial loading handled by the parent template where the template_path, encoding etc will be handled in one place.

I think I also fixed a bug with partials and changing file extensions. The test case was wrong unless I'm misunderstanding the intention.

My branch also has import fixup for python2.5, but I have no idea what 2->3 does with it.
