### PR TITLE
Adding support for using a list of strings as the context for enumerable sections

### DIFF
--- a/pystache/template.py
+++ b/pystache/template.py
@@ -68,7 +68,7 @@ class Template(object):
 
         tag = r"%(otag)s(#|=|&|!|>|\{)?(.+?)\1?%(ctag)s+"
         self.tag_re = re.compile(tag % tags)
-
+        
     def render_sections(self, template, context):
         """Expands sections."""
         while 1:
@@ -121,7 +121,10 @@ class Template(object):
         """Given a tag name and context, finds, escapes, and renders the tag."""
         raw = get_or_attr(context, tag_name, '')
         if not raw and raw is not 0:
-            return ''
+            if tag_name == '.':
+                raw = context
+            else:
+                return ''
         return cgi.escape(unicode(raw))
 
     @modifier('!')

--- a/tests/test_pystache.py
+++ b/tests/test_pystache.py
@@ -78,6 +78,22 @@ class TestPystache(unittest.TestCase):
   <li>Chris</li><li>Tom</li><li>PJ</li>
 </ul>
 """)
+    
+    def test_implicit_iterator(self):
+        template = """
+<ul>
+  {{#users}}
+    <li>{{.}}</li>
+  {{/users}}
+</ul>
+"""
+        context = { 'users': [ 'Chris', 'Tom','PJ' ] }
+        ret = pystache.render(template, context)
+        self.assertEquals(ret, """
+<ul>
+  <li>Chris</li><li>Tom</li><li>PJ</li>
+</ul>
+""")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This patch adds support for passing an array fo strings as the context for a section, consistent with the implementation in mustache.js.

For example:

```
pystache.render("<ul>{{#people}}<li>{{.}}</li>{{/people}}</ul>", { 'people':['Jim','Bob','Joe'] })
```

Outputs:

```
<ul><li>Jim</li><li>Bob</li><li>Joe</li></ul>
```
