### PR TITLE
Added optional support for markupsafe and setuptools/distribute

### DIFF
--- a/pystache/template.py
+++ b/pystache/template.py
@@ -4,6 +4,15 @@ import collections
 import os
 import copy
 
+try:
+    import markupsafe
+    escape = markupsafe.escape
+    literal = markupsafe.Markup
+
+except ImportError:
+    escape = lambda x: cgi.escape(unicode(x))
+    literal = unicode
+
 
 class Modifiers(dict):
     """Dictionary with a decorator for assigning functions to keys."""
@@ -89,7 +98,7 @@ class Template(object):
             elif (not it and section[2] == '^') or (it and section[2] != '^'):
                 replacer = inner
 
-            template = template.replace(section, replacer)
+            template = literal(template.replace(section, replacer))
 
         return template
 
@@ -129,7 +138,7 @@ class Template(object):
         if not raw and raw is not 0:
             return ''
 
-        return cgi.escape(unicode(raw))
+        return escape(raw)
 
     @modifiers.set('!')
     def _render_comment(self, tag_name):
@@ -153,7 +162,7 @@ class Template(object):
     @modifiers.set('&')
     def render_unescaped(self, tag_name):
         """Render a tag without escaping it."""
-        return unicode(self.view.get(tag_name, ''))
+        return literal(self.view.get(tag_name, ''))
 
     def render(self, encoding=None):
         template = self._render_sections(self.template, self.view)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@
 import os
 import sys
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 def publish():
     """Publish to Pypi"""


### PR DESCRIPTION
markupsafe is a library that allows tracking of whether a string is encoded already or not. This will allow pre-encoded strings to be handled by either {{ name }} or {{& name }}
