### PR TITLE
Pystache spacing on a single line was wrong

### DIFF
--- a/pystache/template.py
+++ b/pystache/template.py
@@ -62,7 +62,7 @@ class Template(object):
             'ctag': re.escape(self.ctag)
         }
 
-        section = r"%(otag)s[\#|^]([^\}]*)%(ctag)s\s*(.+?\s*)%(otag)s/\1%(ctag)s"
+        section = r"%(otag)s[\#|^]([^\}]*)%(ctag)s(.+?)%(otag)s/\1%(ctag)s"
         self.section_re = re.compile(section % tags, re.M|re.S)
 
         tag = r"%(otag)s(#|=|&|!|>|\{)?(.+?)\1?%(ctag)s+"

--- a/tests/test_pystache.py
+++ b/tests/test_pystache.py
@@ -75,5 +75,10 @@ class TestPystache(unittest.TestCase):
         ret = pystache.render(template, context)
         self.assertEquals(ret, """<ul><li>Chris</li><li>Tom</li><li>PJ</li></ul>""")
 
+    def test_spacing(self):
+        template = "first{{#spacing}} second {{/spacing}}third"
+        ret = pystache.render(template, {"spacing": True})
+        self.assertEquals(ret, "first second third")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added test for spacing around section tags on a single line. Fixed the problem indicated by the test: a section's contents were being left trimmed.

I'm not an expert at regex. I removed the part that matches white space, so now pystache leaves white space alone. Ideally, it should only touch the white space when a line contains only a mustache tag and nothing else. In such a case, it should delete the line and un-indent the encompassed lines by one level to maintain a nice indentation hierarchy.
