### PR TITLE
Added command line utility to render templates; partials can be passed as a dictionary

### DIFF
--- a/pystache/__init__.py
+++ b/pystache/__init__.py
@@ -6,3 +6,4 @@ def render(template, context=None, **kwargs):
     context = context and context.copy() or {}
     context.update(kwargs)
     return Template(template, context).render()
+

--- a/pystache/commands.py
+++ b/pystache/commands.py
@@ -1,0 +1,30 @@
+from pystache import Template
+import argparse
+import json
+from loader import Loader
+
+def main():
+    parser = argparse.ArgumentParser(description='Render a mustache template with the given context.')
+    parser.add_argument('template',  help='A filename or a template code.')
+    parser.add_argument('context', help='A filename or a JSON string')
+    args = parser.parse_args()
+
+    if args.template.endswith('.mustache'):
+        args.template = args.template[:-9]
+
+    try:
+        template = Loader().load_template(args.template)
+    except IOError:
+        template = args.template
+
+    try:
+        context = json.load(open(args.context))
+    except IOError:
+        context = json.loads(args.context)
+
+    print(Template(template, context).render())
+
+
+if __name__=='__main__':
+    main()
+

--- a/pystache/loader.py
+++ b/pystache/loader.py
@@ -2,14 +2,15 @@ import os
 
 class Loader(object):
     
-    template_extension = 'mustache'
-    template_path = '.'
-    template_encoding = None
+    def __init__(self, paths='.', extension='mustache', encoding=None):
+        self.template_paths = paths
+        self.template_extension = extension
+        self.template_encoding = encoding
     
     def load_template(self, template_name, template_dirs=None, encoding=None, extension=None):
         '''Returns the template string from a file or throws IOError if it non existent'''
         if None == template_dirs:
-            template_dirs = self.template_path
+            template_dirs = self.template_paths
         
         if encoding is not None:
             self.template_encoding = encoding

--- a/pystache/template.py
+++ b/pystache/template.py
@@ -45,10 +45,11 @@ class Template(object):
 
     modifiers = Modifiers()
 
-    def __init__(self, template=None, context=None, **kwargs):
+    def __init__(self, template=None, context=None, partials=None, **kwargs):
         from view import View
 
         self.template = template
+        self.partials = partials
 
         if kwargs:
             context.update(kwargs)
@@ -118,7 +119,7 @@ class Template(object):
 
     def _render_dictionary(self, template, context):
         self.view.context_list.insert(0, context)
-        template = Template(template, self.view)
+        template = Template(template, self.view, self.partials)
         out = template.render()
         self.view.context_list.pop(0)
         return out
@@ -149,9 +150,12 @@ class Template(object):
 
     @modifiers.set('>')
     def _render_partial(self, template_name):
-        from pystache import Loader
-        markup = Loader().load_template(template_name, self.view.template_path, encoding=self.view.template_encoding)
-        template = Template(markup, self.view)
+        if self.partials:
+            template = Template(self.partials[template_name], self.view, self.partials)
+        else:
+            from pystache import Loader
+            markup = Loader().load_template(template_name, self.view.template_path, encoding=self.view.template_encoding)
+            template = Template(markup, self.view)
         return template.render()
 
     @modifiers.set('=')

--- a/pystache/view.py
+++ b/pystache/view.py
@@ -92,3 +92,4 @@ class View(object):
 
     def __str__(self):
         return self.render()
+

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup(name='pystache',
       url='http://github.com/defunkt/pystache',
       packages=['pystache'],
       license='MIT',
+      entry_points = {
+          'console_scripts': ['pystache=pystache.commands:main']},
       classifiers = ( 
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Template `__init__` now accepts the dictionary `partials`.
If `partials` is defined, templates will be loaded using the dictionary instead of the regular "file loader".
Those changes should be retro compatible.

I also added a command line utility to test/render templates.

**Synopsis**

``` bash
usage: pystache [-h] template context

Render a mustache template with the given context.

positional arguments:
  template    A filename or a template code.
  context     A filename or a JSON string

optional arguments:
  -h, --help  show this help message and exit
```
