### PR TITLE
Don't use `is` to compare integers

### DIFF
--- a/pystache/template.py
+++ b/pystache/template.py
@@ -135,7 +135,7 @@ class Template(object):
         raw = self.view.get(tag_name, '')
 
         # For methods with no return value
-        if not raw and raw is not 0:
+        if not raw and raw != 0:
             if tag_name == '.':
                 raw = self.view.context_list[0]
             else:

--- a/pystache/view.py
+++ b/pystache/view.py
@@ -80,7 +80,7 @@ class View(object):
     def __getitem__(self, attr):
         val = self.get(attr, None)
 
-        if not val and val is not 0:
+        if not val and val != 0:
             raise KeyError("Key '%s' does not exist in View" % attr)
         return val
 


### PR DESCRIPTION
This relies on an implementation detail of CPython, thus the test about rendering zeroes fails on PyPy.
