### PR TITLE
Supports both 2.x and 3.x

### DIFF
--- a/examples/unicode_output.py
+++ b/examples/unicode_output.py
@@ -6,4 +6,7 @@ class UnicodeOutput(pystache.View):
     template_path = 'examples'
 
     def name(self):
-        return u'Henri Poincaré'
+        try:
+            return 'Henri Poincaré'.decode('utf-8')
+        except AttributeError:
+            return 'Henri Poincaré'

--- a/pystache/loader.py
+++ b/pystache/loader.py
@@ -20,10 +20,16 @@ class Loader(object):
         file_name = template_name + '.' + self.template_extension
 
         # Given a single directory we'll load from it
-        if isinstance(template_dirs, basestring):
-            file_path = os.path.join(template_dirs, file_name)
+        try:
+            if isinstance(template_dirs, basestring):
+                file_path = os.path.join(template_dirs, file_name)
 
-            return self._load_template_file(file_path)
+                return self._load_template_file(file_path)
+        except NameError:
+            if isinstance(template_dirs, (str, bytes)):
+                file_path = os.path.join(template_dirs, file_name)
+
+                return self._load_template_file(file_path)
             
         # Given a list of directories we'll check each for our file
         for path in template_dirs:
@@ -40,7 +46,11 @@ class Loader(object):
         try:
             template = f.read()
             if self.template_encoding:
-                template = unicode(template, self.template_encoding)
+                try:
+                    template = unicode(template, self.template_encoding)
+                except NameError:
+                    if isinstance(template, bytes):
+                        template = template.decode(self.template_encoding)
         finally:
             f.close()
         

--- a/pystache/template.py
+++ b/pystache/template.py
@@ -10,8 +10,13 @@ try:
     literal = markupsafe.Markup
 
 except ImportError:
-    escape = lambda x: cgi.escape(unicode(x))
-    literal = unicode
+    try:
+        unicode
+        escape = lambda x: cgi.escape(unicode(x))
+        literal = unicode
+    except NameError:
+        escape = lambda x: cgi.escape(str(x))
+        literal = str
 
 
 class Modifiers(dict):
@@ -46,7 +51,7 @@ class Template(object):
     modifiers = Modifiers()
 
     def __init__(self, template=None, context=None, **kwargs):
-        from view import View
+        from pystache.view import View
 
         self.template = template
 

--- a/pystache/view.py
+++ b/pystache/view.py
@@ -36,7 +36,7 @@ class View(object):
         
     def get(self, attr, default=None):
         attr = get_or_attr(self.context_list, attr, getattr(self, attr, default))
-        if hasattr(attr, '__call__') and type(attr) is UnboundMethodType:
+        if hasattr(attr, '__call__') and type(attr) is MethodType:
             return attr()
         else:
             return attr

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -22,14 +22,24 @@ class TestView(unittest.TestCase):
         self.assertEquals(DoubleSection().render(),"""* first\n* second\n* third""")
 
     def test_unicode_output(self):
-        self.assertEquals(UnicodeOutput().render(), u'<p>Name: Henri Poincaré</p>')
+        try:
+            self.assertEquals(UnicodeOutput().render(), '<p>Name: Henri Poincaré</p>'.decode('utf-8'))
+        except AttributeError:
+            self.assertEquals(UnicodeOutput().render(), '<p>Name: Henri Poincaré</p>')
 
     def test_encoded_output(self):
-        self.assertEquals(UnicodeOutput().render('utf8'), '<p>Name: Henri Poincar\xc3\xa9</p>')
+        if 'é' == '\xc3\xa9': # 2.x
+            self.assertEquals(UnicodeOutput().render('utf8'), '<p>Name: Henri Poincar\xc3\xa9</p>')
+        else: # 3.x
+            self.assertEquals(UnicodeOutput().render('utf8'), b'<p>Name: Henri Poincar\xc3\xa9</p>')
 
     def test_unicode_input(self):
-        self.assertEquals(UnicodeInput().render(),
-            u'<p>If alive today, Henri Poincaré would be 156 years old.</p>')
+        try:
+            self.assertEquals(UnicodeInput().render(),
+                '<p>If alive today, Henri Poincaré would be 156 years old.</p>'.decode('utf-8'))
+        except AttributeError:
+            self.assertEquals(UnicodeInput().render(),
+                '<p>If alive today, Henri Poincaré would be 156 years old.</p>')
 
     def test_escaped(self):
         self.assertEquals(Escaped().render(), "<h1>Bear &gt; Shark</h1>")

--- a/tests/test_pystache.py
+++ b/tests/test_pystache.py
@@ -51,16 +51,24 @@ class TestPystache(unittest.TestCase):
         template = "{{#stats}}({{key}} & {{value}}){{/stats}}"
         stats = []
         stats.append({'key': 123, 'value': ['something']})
-        stats.append({'key': u"chris", 'value': 0.900})
+        try:
+            stats.append({'key': unicode("chris"), 'value': 0.900})
+        except NameError:
+            stats.append({'key': "chris", 'value': 0.900})
 
         ret = pystache.render(template, { 'stats': stats })
         self.assertEquals(ret, """(123 & ['something'])(chris & 0.9)""")
 
     def test_unicode(self):
         template = 'Name: {{name}}; Age: {{age}}'
-        ret = pystache.render(template, { 'name': u'Henri Poincaré',
-            'age': 156 })
-        self.assertEquals(ret, u'Name: Henri Poincaré; Age: 156')
+        try:
+            ret = pystache.render(template, { 'name': 'Henri Poincaré'.decode('utf-8'),
+                'age': 156 })
+            self.assertEquals(ret, 'Name: Henri Poincaré; Age: 156'.decode('utf-8'))
+        except AttributeError:
+            ret = pystache.render(template, { 'name': 'Henri Poincaré',
+                'age': 156 })
+            self.assertEquals(ret, 'Name: Henri Poincaré; Age: 156')
 
     def test_sections(self):
         template = """<ul>{{#users}}<li>{{name}}</li>{{/users}}</ul>"""


### PR DESCRIPTION
Added Python 3.x support.

Without markupsafe, both nosetests-2.7 and nosetests-3.2 succeed.

With markupsafe, nosetests-2.7 has one failure on both defunkt/master and holizz/3.x branches (i.e. I wasn't the one who broke it).
