### PR TITLE
Add a failing test case for over-escaping template contents

### DIFF
--- a/examples/repeating_sections.mustache
+++ b/examples/repeating_sections.mustache
@@ -1,0 +1,3 @@
+{{#r1}}<div class='twopeat'></div>
+{{/r1}}{{#r2}}<div class='threepeat'></div>
+{{/r2}}

--- a/examples/repeating_sections.py
+++ b/examples/repeating_sections.py
@@ -1,0 +1,10 @@
+import pystache
+
+class RepeatingSections(pystache.View):
+    template_path = 'examples'
+
+    def r1(self):
+        return [True, True]
+
+    def r2(self):
+        return [True, True, True]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,6 +12,7 @@ from examples.delimiters import Delimiters
 from examples.unicode_output import UnicodeOutput
 from examples.unicode_input import UnicodeInput
 from examples.nested_context import NestedContext
+from examples.repeating_sections import RepeatingSections
 
 class TestView(unittest.TestCase):
     def test_comments(self):
@@ -78,6 +79,10 @@ Again, Welcome!
         view = TemplatePartial(context = {'prop': 'derp'})
         view.template = '''{{>partial_in_partial}}'''
         self.assertEquals(view.render(), 'Hi derp!')
+
+    def test_repeating_sections(self):
+        self.assertEquals(RepeatingSections().render(), 2 * "<div class='twopeat'></div>\n" +
+          3 * "<div class='threepeat'></div>\n" + "\n")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This test case currently breaks when markupsafe is used.
