### PR TITLE
test pystache.render('{{#e}}{{m}}{{/e}}', {'e': {'m': 's'} }) -> 's'

### DIFF
--- a/tests/test_pystache.py
+++ b/tests/test_pystache.py
@@ -74,6 +74,12 @@ class TestPystache(unittest.TestCase):
         context = { 'users': [ 'Chris', 'Tom','PJ' ] }
         ret = pystache.render(template, context)
         self.assertEquals(ret, """<ul><li>Chris</li><li>Tom</li><li>PJ</li></ul>""")
+        
+    def test_single_block_rendering(self):
+        template = """{{#equipment}}{{mainhand}}{{/equipment}}"""
+        context = {'equipment': {'mainhand': 'sweet sword'} }
+        ret = pystache.render(template, context)
+        self.assertEquals(ret, """sweet sword""")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_pystache.py
+++ b/tests/test_pystache.py
@@ -75,7 +75,7 @@ class TestPystache(unittest.TestCase):
         ret = pystache.render(template, context)
         self.assertEquals(ret, """<ul><li>Chris</li><li>Tom</li><li>PJ</li></ul>""")
         
-    def test_single_block_rendering(self):
+    def test_nested_context(self):
         template = """{{#equipment}}{{mainhand}}{{/equipment}}"""
         context = {'equipment': {'mainhand': 'sweet sword'} }
         ret = pystache.render(template, context)


### PR DESCRIPTION
This test, which passes now but didn't pass in v0.3.1, ensures that things like

```
    template = """{{#equipment}}{{mainhand}}{{/equipment}}"""
    context = {'equipment': {'mainhand': 'sweet sword'} }
    ret = pystache.render(template, context) # ret == "sweet sword"
```

work properly.
