### PR TITLE
Allow template path to be passed to render method.

### DIFF
--- a/pystache/__init__.py
+++ b/pystache/__init__.py
@@ -2,7 +2,8 @@ from pystache.template import Template
 from pystache.view import View
 from pystache.loader import Loader
 
-def render(template, context=None, **kwargs):
+def render(template, context=None, path=None, **kwargs):
     context = context and context.copy() or {}
     context.update(kwargs)
-    return Template(template, context).render()
+    view = View(context=context, path=path)
+    return Template(template, view).render()

--- a/pystache/template.py
+++ b/pystache/template.py
@@ -7,11 +7,10 @@ import copy
 try:
     import markupsafe
     escape = markupsafe.escape
-    literal = markupsafe.Markup
-
 except ImportError:
     escape = lambda x: cgi.escape(unicode(x))
-    literal = unicode
+    
+literal = unicode
 
 
 class Modifiers(dict):

--- a/pystache/view.py
+++ b/pystache/view.py
@@ -27,11 +27,12 @@ class View(object):
     template_encoding = None
     template_extension = 'mustache'
     
-    def __init__(self, template=None, context=None, **kwargs):
+    def __init__(self, template=None, context=None, path=None, **kwargs):
         self.template = template
         context = context or {}
         context.update(**kwargs)
 
+        self.template_path = path
         self.context_list = [context]
         
     def get(self, attr, default=None):


### PR DESCRIPTION
The render function can now be called with:

```
str = pystache.render(template, context=context_dict, path="./templates/" )
```
