### PR TITLE
Update setup.py to version 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if sys.argv[-1] == "publish":
     sys.exit()
 
 setup(name='pystache',
-      version='0.3.1',
+      version='0.4.0',
       description='Mustache for Python',
       long_description=open('README.rst').read() + '\n\n' + open('HISTORY.rst').read(),
       author='Chris Wanstrath',


### PR DESCRIPTION
According to history.rst, Pystache has been at version 0.4.0 since January of 2011.  This was not reflected previously in setup.py.  The version hosted on Pypi is still (actually) 0.3.1.  Updating setup.py is necessary before Pypi can be updated to 0.4.0.
