### PR TITLE
Allows to use generators just like lists/tuples.

### DIFF
--- a/pystache/renderengine.py
+++ b/pystache/renderengine.py
@@ -168,7 +168,7 @@ class RenderEngine(object):
                 template = data(template)
                 parsed_template = self._parse(template, delimiters=delims)
                 data = [ data ]
-            elif type(data) not in [list, tuple]:
+            elif not hasattr(data, '__iter__') or isinstance(data, dict):
                 data = [ data ]
 
             parts = []

--- a/tests/test_renderengine.py
+++ b/tests/test_renderengine.py
@@ -376,6 +376,22 @@ class RenderTests(unittest.TestCase):
         context = {'test': (lambda text: 'Hi %s' % text)}
         self._assert_render('Hi Mom', template, context)
 
+    def test_section__generator(self):
+        """
+        Generator expressions should behave the same way as lists do.
+        This actually tests for everything which has an __iter__ method.
+        """
+        template = '{{#gen}}{{.}}{{/gen}}'
+        context = {'gen': (i for i in range(5))}
+        self._assert_render('01234', template, context)
+
+        context = {'gen': xrange(5)}
+        self._assert_render('01234', template, context)
+
+        d = {'1': 1, '2': 2, 'abc': 3}
+        context = {'gen': d.iterkeys()}
+        self._assert_render(''.join(d.keys()), template, context)
+
     def test_section__lambda__tag_in_output(self):
         """
         Check that callable output is treated as a template string (issue #46).


### PR DESCRIPTION
This is done by treating any object with **iter** methods the way only
'list' and 'tuple' objects were treated before. Except dictionaries,
they have an **iter** method too, but that's not what we want.

All 291 tests aswell as the new one pass.

I know that one could work around this on the app side by simply wrapping the generators by a list() before giving them to pystache, but it feels wrong.
