### PR TITLE
Propagate file extension from parent template to partials.

### DIFF
--- a/pystache/template.py
+++ b/pystache/template.py
@@ -150,7 +150,7 @@ class Template(object):
     @modifiers.set('>')
     def _render_partial(self, template_name):
         from pystache import Loader
-        markup = Loader().load_template(template_name, self.view.template_path, encoding=self.view.template_encoding)
+        markup = Loader().load_template(template_name, self.view.template_path, encoding=self.view.template_encoding, extension=self.view.template_extension)
         template = Template(markup, self.view)
         return template.render()
 


### PR DESCRIPTION
I think this will probably continue to work for everyone currently using pystache but will work better for people that are not using the .mustache file extension for their templates/partials.
