### PR TITLE
Fix renderer doctest on Python 3

### DIFF
--- a/pystache/renderer.py
+++ b/pystache/renderer.py
@@ -42,7 +42,7 @@ class Renderer(object):
     >>> partials = {'partial': 'Hello, {{thing}}!'}
     >>> renderer = Renderer(partials=partials)
     >>> # We apply print to make the test work in Python 3 after 2to3.
-    >>> print renderer.render('{{>partial}}', {'thing': 'world'})
+    >>> print (renderer.render('{{>partial}}', {'thing': 'world'}))
     Hello, world!
 
     """


### PR DESCRIPTION
2to3 (at least from cpython 2.7) will not rewrite prints in doctests. This can be fixed by simply putting the print in parentheses.
