### PR TITLE
Updated to not append template_extension if it is already there.

### DIFF
--- a/pystache/loader.py
+++ b/pystache/loader.py
@@ -120,9 +120,27 @@ class Loader(object):
         return self.unicode(b, encoding)
 
     # TODO: unit-test this method.
+    def load_file(self, file_name):
+        """
+        Find and return the template with the given file name.
+
+        Arguments:
+
+          file_name: the file name of the template.
+
+          search_dirs: the list of directories in which to search.
+
+        """
+        locator = self._make_locator()
+
+        path = locator.find_file(file_name, self.search_dirs)
+
+        return self.read(path)
+
+    # TODO: unit-test this method.
     def load_name(self, name):
         """
-        Find and return the template with the given name.
+        Find and return the template with the given template name.
 
         Arguments:
 

--- a/pystache/locator.py
+++ b/pystache/locator.py
@@ -91,7 +91,7 @@ class Locator(object):
         if template_extension is None:
             template_extension = self.template_extension
 
-        if template_extension is not False and not file_name.endswith(template_extension):
+        if template_extension is not False:
             file_name += os.path.extsep + template_extension
 
         return file_name
@@ -122,6 +122,13 @@ class Locator(object):
                                         (repr(file_name), repr(search_dirs)))
 
         return path
+
+    def find_file(self, template_file, search_dirs):
+        """
+        Return the path to a template with the given file name.
+
+        """
+        return self._find_path_required(search_dirs, template_file)
 
     def find_name(self, template_name, search_dirs):
         """

--- a/pystache/locator.py
+++ b/pystache/locator.py
@@ -92,7 +92,8 @@ class Locator(object):
             template_extension = self.template_extension
 
         if template_extension is not False:
-            file_name += os.path.extsep + template_extension
+            if not file_name.endswith(template_extension):
+                file_name += os.path.extsep + template_extension
 
         return file_name
 

--- a/pystache/locator.py
+++ b/pystache/locator.py
@@ -91,9 +91,8 @@ class Locator(object):
         if template_extension is None:
             template_extension = self.template_extension
 
-        if template_extension is not False:
-            if not file_name.endswith(template_extension):
-                file_name += os.path.extsep + template_extension
+        if template_extension is not False and not file_name.endswith(template_extension):
+            file_name += os.path.extsep + template_extension
 
         return file_name
 


### PR DESCRIPTION
locator.py was appending the template extension, even if it was already part of the passed file name. I added a condition to prevent this if the file name already ended in the extension.
