### PR TITLE
Enable defaults.DELIMITERS to be monkey-patched by module users.

### DIFF
--- a/pystache/parser.py
+++ b/pystache/parser.py
@@ -7,7 +7,7 @@ Exposes a parse() function to parse template strings.
 
 import re
 
-from pystache.defaults import DELIMITERS
+from pystache import defaults
 from pystache.parsed import ParsedTemplate
 
 
@@ -228,7 +228,7 @@ class _Parser(object):
 
     def __init__(self, delimiters=None):
         if delimiters is None:
-            delimiters = DELIMITERS
+            delimiters = defaults.DELIMITERS
 
         self._delimiters = delimiters
 

--- a/pystache/tests/test_defaults.py
+++ b/pystache/tests/test_defaults.py
@@ -1,0 +1,68 @@
+import unittest
+
+import pystache
+import pystache.defaults
+
+from pystache.tests.common import AssertStringMixin
+
+
+class TestDefaults(unittest.TestCase, AssertStringMixin):
+    """Set of tests to ensure that the user can override defaults."""
+
+    def setUp(self):
+        """save all the defaults."""
+        defaults = [
+            'DECODE_ERRORS', 'DELIMITERS',
+            'FILE_ENCODING', 'MISSING_TAGS', 
+            'SEARCH_DIRS', 'STRING_ENCODING',
+            'TAG_ESCAPE', 'TEMPLATE_EXTENSION'
+        ]
+        self.saved = {}
+        for e in defaults:
+            self.saved[e] = getattr(pystache.defaults, e)
+
+    def tearDown(self):
+        for key, value in self.saved.items():
+            setattr(pystache.defaults, key, value)
+
+    def test_tag_escape(self):
+        """Test that TAG_ESCAPE default takes effect."""
+        template = u"{{foo}}"
+        config = {'foo': '<'}
+        actual = pystache.render(template, config)
+        self.assertString(actual, u"&lt;")
+
+        pystache.defaults.TAG_ESCAPE = lambda u: u
+        actual = pystache.render(template, config)
+        self.assertString(actual, u"<")
+
+    def test_delimiters(self):
+        """Test that DELIMITERS default takes effect."""
+        template = u"[[foo]]{{foo}}"
+        config = {'foo': 'FOO'}
+        actual = pystache.render(template, config)
+        self.assertString(actual, u"[[foo]]FOO")
+
+        pystache.defaults.DELIMITERS = ('[[', ']]')
+        actual = pystache.render(template, config)
+        self.assertString(actual, u"FOO{{foo}}")
+
+    def test_missing_tags(self):
+        """Test that MISSING_TAGS default take effect."""
+        template = u"{{foo}}"
+        config = {}
+        actual = pystache.render(template, config)
+        self.assertString(actual, u"")
+
+        pystache.defaults.MISSING_TAGS = 'strict'
+
+        # In theory this should work, but for some reason doesn't,
+        # instead another exception is raised
+        # self.assertRaises(pystache.context.KeyNotFoundError,
+        #                  pystache.render, (template, config))
+        try:
+            pystache.render(template, config)
+        except pystache.context.KeyNotFoundError, e:
+            return
+
+        self.fail()

--- a/pystache/tests/test_defaults.py
+++ b/pystache/tests/test_defaults.py
@@ -28,41 +28,33 @@ class TestDefaults(unittest.TestCase, AssertStringMixin):
     def test_tag_escape(self):
         """Test that TAG_ESCAPE default takes effect."""
         template = u"{{foo}}"
-        config = {'foo': '<'}
-        actual = pystache.render(template, config)
+        context = {'foo': '<'}
+        actual = pystache.render(template, context)
         self.assertString(actual, u"&lt;")
 
         pystache.defaults.TAG_ESCAPE = lambda u: u
-        actual = pystache.render(template, config)
+        actual = pystache.render(template, context)
         self.assertString(actual, u"<")
 
     def test_delimiters(self):
         """Test that DELIMITERS default takes effect."""
         template = u"[[foo]]{{foo}}"
-        config = {'foo': 'FOO'}
-        actual = pystache.render(template, config)
+        context = {'foo': 'FOO'}
+        actual = pystache.render(template, context)
         self.assertString(actual, u"[[foo]]FOO")
 
         pystache.defaults.DELIMITERS = ('[[', ']]')
-        actual = pystache.render(template, config)
+        actual = pystache.render(template, context)
         self.assertString(actual, u"FOO{{foo}}")
 
     def test_missing_tags(self):
         """Test that MISSING_TAGS default take effect."""
         template = u"{{foo}}"
-        config = {}
-        actual = pystache.render(template, config)
+        context = {}
+        actual = pystache.render(template, context)
         self.assertString(actual, u"")
 
         pystache.defaults.MISSING_TAGS = 'strict'
 
-        # In theory this should work, but for some reason doesn't,
-        # instead another exception is raised
-        # self.assertRaises(pystache.context.KeyNotFoundError,
-        #                  pystache.render, (template, config))
-        try:
-            pystache.render(template, config)
-        except pystache.context.KeyNotFoundError, e:
-            return
-
-        self.fail()
+        self.assertRaises(pystache.context.KeyNotFoundError,
+                          pystache.render, template, context)


### PR DESCRIPTION
This updates the way in which default.DELIMITERS is used to
enable simple monkey-patching should a user desire.

Monkey-patching isn't the preferred approach however, it can
at times be useful and it simple to support.

Additionally, test cases are added to ensure certain defaults can
be monkey-patched at run-time.
