### PR TITLE
Append file:line.col information to strict exceptions.

### DIFF
--- a/pystache/renderengine.py
+++ b/pystache/renderengine.py
@@ -97,12 +97,12 @@ class RenderEngine(object):
     #   The returned value MUST be rendered against the default delimiters,
     #   then interpolated in place of the lambda.
     #
-    def fetch_string(self, context, name):
+    def fetch_string(self, context, name, location):
         """
         Get a value from the given context as a basestring instance.
 
         """
-        val = self.resolve_context(context, name)
+        val = self.resolve_context(context, name, location)
 
         if callable(val):
             # Return because _render_value() is already a string.
@@ -113,12 +113,12 @@ class RenderEngine(object):
 
         return val
 
-    def fetch_section_data(self, context, name):
+    def fetch_section_data(self, context, name, location):
         """
         Fetch the value of a section as a list.
 
         """
-        data = self.resolve_context(context, name)
+        data = self.resolve_context(context, name, location)
 
         # From the spec:
         #

--- a/pystache/tests/test_renderengine.py
+++ b/pystache/tests/test_renderengine.py
@@ -94,7 +94,7 @@ class RenderTests(unittest.TestCase, AssertStringMixin, AssertExceptionMixin):
         engine = kwargs.get('engine', self._engine())
 
         if partials is not None:
-            engine.resolve_partial = lambda key: unicode(partials[key])
+            engine.resolve_partial = lambda key, location: unicode(partials[key])
 
         context = ContextStack(*context)
 
@@ -113,7 +113,7 @@ class RenderTests(unittest.TestCase, AssertStringMixin, AssertExceptionMixin):
         """
         engine = self._engine()
         partials = {'partial': u"{{person}}"}
-        engine.resolve_partial = lambda key: partials[key]
+        engine.resolve_partial = lambda key, location: partials[key]
 
         self._assert_render(u'Hi Mom', 'Hi {{>partial}}', {'person': 'Mom'}, engine=engine)
 


### PR DESCRIPTION
When debugging a complex (or simply long) template it is very
useful to the exact location causing errors.

This adds a 'location' field to appropriate exception objects
which can then be displayed to the user by appropriate error
handling code.

The current design is backwards compatible, and the filename
that is encoded in the location object defaults to '<string>'
unless specifically overridden by the user.

This patch opens the scope for more intelligent defaults
throughout the library, however this patch tries to avoid
significant changes to the external API.

Currently to take advantage of the changes a ParsedTemplate
object must be manually created using the parser._Parser.parse
method, which has a second (optional) argument 'name'. This
name is copied through to the exception's location field in
the case of an error.

There is a large design scope for the way in which this may
be implemented.  The current approach tries to balance the
propagation of location objects through the API, while avoiding
too much duplication of code.
