### PR TITLE
Support mappings that are not simply dicts.

### DIFF
--- a/pystache/context.py
+++ b/pystache/context.py
@@ -7,12 +7,14 @@ The Mustache spec makes a special distinction between two types of context
 stack elements: hashes and objects.  For the purposes of interpreting the
 spec, we define these categories mutually exclusively as follows:
 
- (1) Hash: an item whose type is a subclass of dict.
+ (1) Hash: an item whose type is a subclass of collections.Mapping.
 
  (2) Object: an item that is neither a hash nor an instance of a
      built-in type.
 
 """
+
+import collections
 
 from pystache.common import PystacheError
 
@@ -43,7 +45,7 @@ def _get_value(context, key):
     The ContextStack.get() docstring documents this function's intended behavior.
 
     """
-    if isinstance(context, dict):
+    if isinstance(context, collections.Mapping):
         # Then we consider the argument a "hash" for the purposes of the spec.
         #
         # We do a membership test to avoid using exceptions for flow control

--- a/pystache/context.py
+++ b/pystache/context.py
@@ -9,6 +9,12 @@ spec, we define these categories mutually exclusively as follows:
 
  (1) Hash: an item whose type is a subclass of collections.Mapping.
 
+    .. note::
+
+        collections.Mapping is used instead of a dict in order to allow other
+        mapping types to be valid contexts. See 
+        `Issue 144 <https://github.com/defunkt/pystache/pull/144>`
+
  (2) Object: an item that is neither a hash nor an instance of a
      built-in type.
 
@@ -47,6 +53,9 @@ def _get_value(context, key):
     """
     if isinstance(context, collections.Mapping):
         # Then we consider the argument a "hash" for the purposes of the spec.
+        # Using collections.Mapping allows other mapping types to be registered 
+        # as valid "hash" contexts. See 
+        # `Issue 144 <https://github.com/defunkt/pystache/pull/144>`
         #
         # We do a membership test to avoid using exceptions for flow control
         # (e.g. catching KeyError).


### PR DESCRIPTION
As part of a recent project I needed Pystache to work with a custom class that followed the collections.Mapping spec and was not directly subclassed from dict. As a result, Pystache wouldn't retrieve items from the mapping. This patch fixes the context to test type against collections.Mapping rather than dict.
