### PR TITLE
Escape dots in key parts

### DIFF
--- a/pystache/context.py
+++ b/pystache/context.py
@@ -275,7 +275,16 @@ class ContextStack(object):
             except IndexError:
                 raise KeyNotFoundError(".", "empty context stack")
 
-        parts = name.split('.')
+        # Allow a "part" to contain a "." by escaping it in the raw template.
+        parts = []
+        ref_blocks = name.split('\\.')
+        for i in range(len(ref_blocks)):
+          block_parts = ref_blocks[i].split('.')
+          if i > 0:
+            parts[-1] += '.%s' % block_parts[0]
+            parts += block_parts[1:]
+          else:
+            parts += block_parts
 
         try:
             result = self._get_simple(parts[0])

--- a/pystache/tests/test_context.py
+++ b/pystache/tests/test_context.py
@@ -434,6 +434,16 @@ class ContextStackTestCase(unittest.TestCase, AssertIsMixin, AssertStringMixin,
         stack = ContextStack({"a": {"b": {"c": {"d": {"e": {"f": {"g": "w00t!"}}}}}}})
         self.assertEqual(stack.get(name), "w00t!")
 
+    def test_dot_notation_escaped(self):
+        name = "foo\.bar"
+        stack = ContextStack({"foo.bar": "baz"})
+        self.assertEqual(stack.get(name), "baz")
+
+        # Works at any component depth.
+        name = "zoo.foo\.bar"
+        stack = ContextStack({"zoo": {"foo.bar": "baz"}})
+        self.assertEqual(stack.get(name), "baz")
+
     def test_dot_notation__user_object(self):
         name = "foo.bar"
         stack = ContextStack({"foo": Attachable(bar="baz")})


### PR DESCRIPTION
Hi there,

We're enjoying Pystache at Foursquare and ran into a case where it would be useful to reference key parts containing periods. I came across an accepted pull request in Mustache.js here https://github.com/bitovi/canjs/commit/ffa9afb7b917cc304bb8f52fc850ff26b3c58607 and decided to give it a try for Pystache. Please let us know if you see any significant issues with this change. Looking forward to hearing your thoughts and thanks for your hard work on Pystache!

Best,
Josh
