### PR TITLE
Fix syntax error in Python 3.3.

### DIFF
--- a/pystache/parser.py
+++ b/pystache/parser.py
@@ -147,7 +147,7 @@ class _PartialNode(object):
     def render(self, engine, context):
         template = engine.resolve_partial(self.key)
         # Indent before rendering.
-        template = re.sub(NON_BLANK_RE, self.indent + ur'\1', template)
+        template = re.sub(NON_BLANK_RE, self.indent + u'\\1', template)
 
         return engine.render(template, context)
 

--- a/pystache/parser.py
+++ b/pystache/parser.py
@@ -12,7 +12,7 @@ from pystache.parsed import ParsedTemplate
 
 
 END_OF_LINE_CHARACTERS = [u'\r', u'\n']
-NON_BLANK_RE = re.compile(ur'^(.)', re.M)
+NON_BLANK_RE = re.compile(u'^(.)', re.M)
 
 
 # TODO: add some unit tests for this.


### PR DESCRIPTION
“Unicode Raw” strings are no longer supported in Python 3.3, and cause a syntax error. See http://bugs.python.org/issue15096.

I understand that the source distribution of Pystache is not intended to by Python 3 compatible out of the box, but this syntax error seems unnecessary. With this change, the code is functionally equivalent, and the syntax is compatible with all Python versions.
