### PR TITLE
use `load_file` instead of `read` in renderer

### DIFF
--- a/pystache/renderer.py
+++ b/pystache/renderer.py
@@ -385,7 +385,7 @@ class Renderer(object):
 
         """
         loader = self._make_loader()
-        template = loader.read(template_path)
+        template = loader.load_file(template_path)
 
         return self._render_string(template, *context, **kwargs)
 


### PR DESCRIPTION
`load_file` takes search_dirs into account, so
it properly discovers templates when using
`search_dirs`--`read` uses leans on `common.read`
which does not handle `search_dirs`
