### PR TITLE
Allow ParsedTemplate as partials

### DIFF
--- a/pystache/__init__.py
+++ b/pystache/__init__.py
@@ -10,4 +10,4 @@ from pystache.init import parse, render, Renderer, TemplateSpec
 
 __all__ = ['parse', 'render', 'Renderer', 'TemplateSpec']
 
-__version__ = '0.5.4'  # Also change in setup.py.
+__version__ = '0.5.4a'  # Also change in setup.py.

--- a/pystache/context.py
+++ b/pystache/context.py
@@ -66,6 +66,10 @@ def _get_value(context, key):
             #   See the following issue for implementation ideas:
             #     http://bugs.python.org/issue7559
             pass
+        except UnicodeEncodeError:
+           # we managed to get a tag that has unicode in it, and getattr()
+           # doesn't support that
+           pass
         else:
             # TODO: consider using EAFP here instead.
             #   http://docs.python.org/glossary.html#term-eafp

--- a/pystache/parser.py
+++ b/pystache/parser.py
@@ -147,7 +147,8 @@ class _PartialNode(object):
     def render(self, engine, context):
         template = engine.resolve_partial(self.key)
         # Indent before rendering.
-        template = re.sub(NON_BLANK_RE, self.indent + ur'\1', template)
+        if not isinstance(template, ParsedTemplate):
+            template = re.sub(NON_BLANK_RE, self.indent + ur'\1', template)
 
         return engine.render(template, context)
 

--- a/pystache/parser.py
+++ b/pystache/parser.py
@@ -317,7 +317,10 @@ class _Parser(object):
                 continue
 
             if tag_type == '/':
-                if tag_key != section_key:
+                parsed_section_key = section_key.split("|")[0]
+                if parsed_section_key:
+                    parsed_section_key = parsed_section_key.strip()
+                if tag_key != parsed_section_key:
                     raise ParsingError("Section end tag mismatch: %s != %s" % (tag_key, section_key))
 
                 # Restore previous state with newly found section data.

--- a/pystache/parser.py
+++ b/pystache/parser.py
@@ -18,7 +18,7 @@ NON_BLANK_RE = re.compile(ur'^(.)', re.M)
 # TODO: add some unit tests for this.
 # TODO: add a test case that checks for spurious spaces.
 # TODO: add test cases for delimiters.
-def parse(template, delimiters=None):
+def parse(template, delimiters=None, liberal_sections=False):
     """
     Parse a unicode template string and return a ParsedTemplate instance.
 
@@ -37,7 +37,7 @@ def parse(template, delimiters=None):
     """
     if type(template) is not unicode:
         raise Exception("Template is not unicode: %s" % type(template))
-    parser = _Parser(delimiters)
+    parser = _Parser(delimiters, liberal_sections=liberal_sections)
     return parser.parse(template)
 
 
@@ -227,11 +227,12 @@ class _Parser(object):
     _delimiters = None
     _template_re = None
 
-    def __init__(self, delimiters=None):
+    def __init__(self, delimiters=None, liberal_sections=False):
         if delimiters is None:
             delimiters = defaults.DELIMITERS
 
         self._delimiters = delimiters
+        self.liberal_sections = liberal_sections
 
     def _compile_delimiters(self):
         self._template_re = _compile_template_re(self._delimiters)
@@ -317,13 +318,15 @@ class _Parser(object):
                 continue
 
             if tag_type == '/':
-                if tag_key != section_key:
+                if tag_key is not None and section_key is not None and tag_key.lower() != section_key.lower():
                     parsed_section_key = section_key.split("|")[0]
                     if parsed_section_key:
                         parsed_section_key = parsed_section_key.strip()
-                    if tag_key != parsed_section_key:
-                        raise ParsingError("Section end tag mismatch: %s != %s" % (tag_key, section_key))
-
+                    if tag_key.lower() != parsed_section_key.lower():
+                        if not self.liberal_sections:
+                            raise ParsingError("Section end tag mismatch: %s != %s" % (tag_key, section_key))
+                        else:
+                            tag_key = parsed_section_key
                 # Restore previous state with newly found section data.
                 parsed_section = parsed_template
 

--- a/pystache/parser.py
+++ b/pystache/parser.py
@@ -317,11 +317,12 @@ class _Parser(object):
                 continue
 
             if tag_type == '/':
-                parsed_section_key = section_key.split("|")[0]
-                if parsed_section_key:
-                    parsed_section_key = parsed_section_key.strip()
-                if tag_key != parsed_section_key:
-                    raise ParsingError("Section end tag mismatch: %s != %s" % (tag_key, section_key))
+                if tag_key != section_key:
+                    parsed_section_key = section_key.split("|")[0]
+                    if parsed_section_key:
+                        parsed_section_key = parsed_section_key.strip()
+                    if tag_key != parsed_section_key:
+                        raise ParsingError("Section end tag mismatch: %s != %s" % (tag_key, section_key))
 
                 # Restore previous state with newly found section data.
                 parsed_section = parsed_template

--- a/pystache/renderengine.py
+++ b/pystache/renderengine.py
@@ -9,6 +9,7 @@ import re
 
 from pystache.common import is_string
 from pystache.parser import parse
+from pystache.parsed import ParsedTemplate
 
 
 def context_get(stack, name):
@@ -176,6 +177,9 @@ class RenderEngine(object):
           context_stack: a ContextStack instance.
 
         """
-        parsed_template = parse(template, delimiters)
+        if isinstance(template, ParsedTemplate):
+            parsed_template = template
+        else:
+            parsed_template = parse(template, delimiters)
 
         return parsed_template.render(self, context_stack)

--- a/pystache/renderer.py
+++ b/pystache/renderer.py
@@ -265,7 +265,9 @@ class Renderer(object):
                 raise TemplateNotFoundError("Name %s not found in partials: %s" %
                                             (repr(name), type(partials)))
 
-            # RenderEngine requires that the return value be unicode.
+            # RenderEngine requires that the return value be unicode or a parsed template.
+            if isinstance(template, ParsedTemplate):            
+                return template
             return self._to_unicode_hard(template)
 
         return load_partial

--- a/pystache/tests/test_renderer.py
+++ b/pystache/tests/test_renderer.py
@@ -12,6 +12,7 @@ import unittest
 
 from examples.simple import Simple
 from pystache import Renderer
+from pystache.parser import parse
 from pystache import TemplateSpec
 from pystache.common import TemplateNotFoundError
 from pystache.context import ContextStack, KeyNotFoundError
@@ -367,6 +368,16 @@ class RendererTests(unittest.TestCase, AssertStringMixin):
         # If the next line failed, we would get the following error:
         #   TypeError: decoding Unicode is not supported
         self.assertEqual(resolve_partial("partial"), "foo")
+
+    def test_make_resolve_partial__parsed(self):
+        """
+        Test _make_resolve_partial__parsed(): that we can take ParsedTemplates as partials
+
+        """
+        partials = {"partial": parse(u"Hello, {{person}}")}
+        renderer = Renderer(partials=partials)
+        actual = renderer.render(u"{{>partial}}", {"person": "foo"})
+        self.assertString(actual, u"Hello, foo")
 
     def test_render_name(self):
         """Test the render_name() method."""

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ else:
     setup = dist.setup
 
 
-VERSION = '0.5.4'  # Also change in pystache/__init__.py.
+VERSION = '0.5.4a'  # Also change in pystache/__init__.py.
 
 FILE_ENCODING = 'utf-8'
 


### PR DESCRIPTION
The current engine only allows unicode strings as partials; using a pre-parsed template provides a fairly significant performance benefit.

Included a test to verify this as working.
