### PR TITLE
changed imports to relative imports

### DIFF
--- a/pystache/__init__.py
+++ b/pystache/__init__.py
@@ -1,4 +1,3 @@
-
 """
 TODO: add a docstring.
 
@@ -6,7 +5,7 @@ TODO: add a docstring.
 
 # We keep all initialization code in a separate module.
 
-from pystache.init import parse, render, Renderer, TemplateSpec
+from .init import parse, render, Renderer, TemplateSpec
 
 __all__ = ['parse', 'render', 'Renderer', 'TemplateSpec']
 

--- a/pystache/context.py
+++ b/pystache/context.py
@@ -14,7 +14,7 @@ spec, we define these categories mutually exclusively as follows:
 
 """
 
-from pystache.common import PystacheError
+from .common import PystacheError
 
 
 # This equals '__builtin__' in Python 2 and 'builtins' in Python 3.

--- a/pystache/defaults.py
+++ b/pystache/defaults.py
@@ -17,7 +17,7 @@ except ImportError:
 import os
 import sys
 
-from pystache.common import MissingTags
+from .common import MissingTags
 
 
 # How to handle encoding errors when decoding strings from str to unicode.

--- a/pystache/init.py
+++ b/pystache/init.py
@@ -5,9 +5,9 @@ This module contains the initialization logic called by __init__.py.
 
 """
 
-from pystache.parser import parse
-from pystache.renderer import Renderer
-from pystache.template_spec import TemplateSpec
+from .parser import parse
+from .renderer import Renderer
+from .template_spec import TemplateSpec
 
 
 def render(template, context=None, **kwargs):

--- a/pystache/loader.py
+++ b/pystache/loader.py
@@ -8,9 +8,9 @@ This module provides a Loader class for locating and reading templates.
 import os
 import sys
 
-from pystache import common
-from pystache import defaults
-from pystache.locator import Locator
+from . import common
+from . import defaults
+from .locator import Locator
 
 
 # We make a function so that the current defaults take effect.

--- a/pystache/locator.py
+++ b/pystache/locator.py
@@ -9,8 +9,8 @@ import os
 import re
 import sys
 
-from pystache.common import TemplateNotFoundError
-from pystache import defaults
+from .common import TemplateNotFoundError
+from . import defaults
 
 
 class Locator(object):

--- a/pystache/parser.py
+++ b/pystache/parser.py
@@ -7,8 +7,8 @@ Exposes a parse() function to parse template strings.
 
 import re
 
-from pystache import defaults
-from pystache.parsed import ParsedTemplate
+from . import defaults
+from .parsed import ParsedTemplate
 
 
 END_OF_LINE_CHARACTERS = [u'\r', u'\n']

--- a/pystache/renderengine.py
+++ b/pystache/renderengine.py
@@ -7,8 +7,8 @@ Defines a class responsible for rendering logic.
 
 import re
 
-from pystache.common import is_string
-from pystache.parser import parse
+from .common import is_string
+from .parser import parse
 
 
 def context_get(stack, name):

--- a/pystache/renderer.py
+++ b/pystache/renderer.py
@@ -7,14 +7,14 @@ This module provides a Renderer class to render templates.
 
 import sys
 
-from pystache import defaults
-from pystache.common import TemplateNotFoundError, MissingTags, is_string
-from pystache.context import ContextStack, KeyNotFoundError
-from pystache.loader import Loader
-from pystache.parsed import ParsedTemplate
-from pystache.renderengine import context_get, RenderEngine
-from pystache.specloader import SpecLoader
-from pystache.template_spec import TemplateSpec
+from . import defaults
+from .common import TemplateNotFoundError, MissingTags, is_string
+from .context import ContextStack, KeyNotFoundError
+from .loader import Loader
+from .parsed import ParsedTemplate
+from .renderengine import context_get, RenderEngine
+from .specloader import SpecLoader
+from .template_spec import TemplateSpec
 
 
 class Renderer(object):

--- a/pystache/specloader.py
+++ b/pystache/specloader.py
@@ -7,7 +7,7 @@ This module supports customized (aka special or specified) template loading.
 
 import os.path
 
-from pystache.loader import Loader
+from .loader import Loader
 
 
 # TODO: add test cases for this class.


### PR DESCRIPTION
Hello defunkt, 

I made changes from import pystache.something to import .something so that pystache can be used even when its module is not in sys.path. I needed this change in order to run on google app engine (where I am not allowed to install modules) and for various reasons I was not allowed to change sys.path.

Massimo
