### PR TITLE
[CLI] support mustache's style YAML frontmatters

### DIFF
--- a/pystache/commands/render.py
+++ b/pystache/commands/render.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding -*- : utf-8
 
 """
 This module provides command-line access to pystache.
@@ -6,28 +6,12 @@ This module provides command-line access to pystache.
 Run this script using the -h option for command-line help.
 
 """
-
-
-try:
-    import json
-except:
-    # The json module is new in Python 2.6, whereas simplejson is
-    # compatible with earlier versions.
-    try:
-        import simplejson as json
-    except ImportError:
-        # Raise an error with a type different from ImportError as a hack around
-        # this issue:
-        #   http://bugs.python.org/issue7559
-        from sys import exc_info
-        ex_type, ex_value, tb = exc_info()
-        new_ex = Exception("%s: %s" % (ex_type.__name__, ex_value))
-        raise new_ex.__class__, new_ex, tb
+import sys
+import yaml
 
 # The optparse module is deprecated in Python 2.7 in favor of argparse.
 # However, argparse is not available in Python 2.6 and earlier.
 from optparse import OptionParser
-import sys
 
 # We use absolute imports here to allow use of this script from its
 # location in source control (e.g. for development purposes).
@@ -35,19 +19,24 @@ import sys
 #
 #   ValueError: Attempted relative import in non-package
 #
-from pystache.common import TemplateNotFoundError
 from pystache.renderer import Renderer
 
-
 USAGE = """\
-%prog [-h] template context
+%prog [-hv] template [context]
 
 Render a mustache template with the given context.
 
 positional arguments:
-  template    A filename or template string.
-  context     A filename or JSON string."""
 
+  template    A filename or template string.
+  context     A yaml or json filename, or a json string
+
+if context is omitted, pystache read a YAML frontmatter
+as render context from standard input if not a tty.
+
+"""
+
+MARKER = '---\n'  # marker for yaml sections (see mustache)
 
 def parse_args(sys_argv, usage):
     """
@@ -60,15 +49,29 @@ def parse_args(sys_argv, usage):
     parser.add_option('-v', '--version', action="store_true",
                       dest="show_version", default=False,
                       help="show version and exit")
+    parser.add_option('-y', action="store_true", dest="yaml", default=False,
+                      help="accept yaml as context format")
     options, args = parser.parse_args(args)
     if options.show_version:
         import pystache
         print("pystache %s" % pystache.__version__)
         sys.exit(0)
+    if len(args) == 1:
+        template, context = args[0], None
+    else:
+        template, context = args
 
-    template, context = args
+    if options.show_version:
+        import pystache
+        print("pystache %s" % pystache.__version__)
+        sys.exit(0)
 
-    return template, context
+    if len(args) == 1:
+        template, context = args[0], None
+    else:
+        template, context = args
+
+    return template, context, options
 
 
 # TODO: verify whether the setup() method's entry_points argument
@@ -76,27 +79,68 @@ def parse_args(sys_argv, usage):
 #
 #     http://packages.python.org/distribute/setuptools.html#automatic-script-creation
 #
-def main(sys_argv=sys.argv):
-    template, context = parse_args(sys_argv, USAGE)
+MARKER = '---\n'
 
-    if template.endswith('.mustache'):
-        template = template[:-9]
+def arg2text(arg):
+    """ get text from comand line arg """
+    import errno
+    if not isinstance(arg, str):
+        return arg.read().decode('utf-8')  # FIXME
+    else:
+        try:
+            if sys.version_info[0] == 3:
+                with open(arg, encoding='utf-8') as data:
+                    return data.read()
+            else:
+                with open(arg, 'rb') as data:
+                    return data.read().decode('utf-8')
+        except IOError, err:
+            if err.errno == errno.ENOENT:
+                # not a file, assumming first arg is template literal
+                return arg
 
+def extract_context(content, greedy=False):
+    if content.startswith(MARKER):
+        end = content.find(MARKER, len(MARKER))
+        frontmatter = content[len(MARKER):end]
+        content = content[end+len(MARKER):]
+        context = yaml.load(frontmatter)
+    elif greedy:
+        frontmatter = content
+        content = None
+        context = yaml.load(frontmatter)
+    else:
+        context = {}
+    return context, content
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv
+
+    template, context, options = parse_args(argv, USAGE)
+
+    if context is None and not sys.stdin.isatty():
+        user_context = yaml.load(sys.stdin)
+    elif context:
+        user_context = yaml.load(arg2text(context))
+    else:
+        user_context = {}
+
+    # assuming first arg is a filename or template literal
+    template = arg2text(template)
+    template_context, template = extract_context(template)
+    if template.startswith(MARKER):
+        end = template.find(MARKER, len(MARKER))
+        frontmatter = template[len(MARKER):end]
+        template = template[end+len(MARKER):]
+        template_context = yaml.load(frontmatter)
+    else:
+        template_context = {}
+
+    template_context.update(user_context)
     renderer = Renderer()
+    rendered = renderer.render(template, template_context)
+    print(rendered)
 
-    try:
-        template = renderer.load_template(template)
-    except TemplateNotFoundError:
-        pass
-
-    try:
-        context = json.load(open(context))
-    except IOError:
-        context = json.loads(context)
-
-    rendered = renderer.render(template, context)
-    print rendered
-
-
-if __name__=='__main__':
+if __name__ == '__main__':
     main()

--- a/pystache/commands/render.py
+++ b/pystache/commands/render.py
@@ -57,7 +57,14 @@ def parse_args(sys_argv, usage):
     args = sys_argv[1:]
 
     parser = OptionParser(usage=usage)
+    parser.add_option('-v', '--version', action="store_true",
+                      dest="show_version", default=False,
+                      help="show version and exit")
     options, args = parser.parse_args(args)
+    if options.show_version:
+        import pystache
+        print("pystache %s" % pystache.__version__)
+        sys.exit(0)
 
     template, context = args
 

--- a/pystache/tests/common.py
+++ b/pystache/tests/common.py
@@ -234,4 +234,4 @@ class Attachable(object):
     def __repr__(self):
         return "%s(%s)" % (self.__class__.__name__,
                            ", ".join("%s=%s" % (k, repr(v))
-                                     for k, v in self.__args__.iteritems()))
+                                     for k, v in sorted(self.__args__.iteritems())))

--- a/setup.py
+++ b/setup.py
@@ -317,7 +317,7 @@ Run the following command and commit the changes--
 #
 #   https://github.com/simplejson/simplejson/blob/master/CHANGES.txt
 #
-requires = []
+requires = ['PyYAML==3.11']
 if py_version < (2, 5):
     requires.append('simplejson<2.1')
 elif py_version < (2, 6):


### PR DESCRIPTION
- make pystache dependant of PyYAML 3.11
- `context` is now an optional positional argument and
  when pystache is invoked in a pipe it excepts to read
  a mustache's style YAML frontmatter from stdin.
- added option -y to expect `context` positional argument
  in yaml format when interpreted as a file path
  (FIXME: should check file extension)
