### PR TITLE
Test failures in Windows due to newlines

### DIFF
--- a/pystache/common.py
+++ b/pystache/common.py
@@ -45,7 +45,7 @@ def read(path):
     # read() method returns byte strings (strings of type `str` in Python 2),
     # whereas in Python 3, the file object returns unicode strings (strings
     # of type `str` in Python 3).
-    f = open(path, 'rb')
+    f = open(path, 'rbU')
     # We avoid use of the with keyword for Python 2.4 support.
     try:
         return f.read()


### PR DESCRIPTION
Example failure:

```
Failure
Traceback (most recent call last):
  File "C:\Python27\lib\unittest\case.py", line 329, in run
    testMethod()
  File "C:\Ivan\pystache\pystache\tests\test_examples.py", line 80, in test_delimiters
    """)
  File "C:\Ivan\pystache\pystache\tests\common.py", line 160, in assertString
    self.assertEqual(actual, expected, make_message("different characters"))
  File "C:\Python27\lib\unittest\case.py", line 513, in assertEqual
    assertion_func(first, second, msg=msg)
  File "C:\Python27\lib\unittest\case.py", line 924, in assertMultiLineEqual
    self.fail(self._formatMessage(msg, standardMsg))
  File "C:\Python27\lib\unittest\case.py", line 410, in fail
    raise self.failureException(msg)
AssertionError: String mismatch: different characters

        Expected: """* It worked the first time.
* And it worked the second time.
* Then, surprisingly, it worked the third time.
"""
        Actual:   """* It worked the first time.
* And it worked the second time.
* Then, surprisingly, it worked the third time.
"""

        Expected: u'* It worked the first time.\n* And it worked the second time.\n* Then, surprisingly, it worked the third time.\n'
        Actual:   u'* It worked the first time.\r\n* And it worked the second time.\r\n* Then, surprisingly, it worked the third time.\r\n'
```