### PR TITLE
Template is not found when extension is an empty string on Linux

### DIFF
--- a/pystache/locator.py
+++ b/pystache/locator.py
@@ -91,7 +91,7 @@ class Locator(object):
         if template_extension is None:
             template_extension = self.template_extension
 
-        if template_extension is not False:
+        if template_extension:
             file_name += os.path.extsep + template_extension
 
         return file_name


### PR DESCRIPTION
Locator.make_file_name(...) always appends a dot at the end of filename when the extension string is empty. This is not a problem on Windows since the trailing dot is stripped but on Linux the file is never found.